### PR TITLE
fix: Utf8 encoding and index page creation

### DIFF
--- a/src/com/hannonhill/umt/service/FileSystem.java
+++ b/src/com/hannonhill/umt/service/FileSystem.java
@@ -198,7 +198,7 @@ public class FileSystem
     {
         StringBuilder stringBuilder = new StringBuilder();
         String ls = System.getProperty("line.separator");
-        Charset charset = Charset.forName("ISO-8859-1");
+        Charset charset = Charset.forName("UTF-8");
 
         try (BufferedReader reader = Files.newBufferedReader(pageFile, charset))
         {

--- a/src/com/hannonhill/umt/service/RestApi.java
+++ b/src/com/hannonhill/umt/service/RestApi.java
@@ -5,8 +5,10 @@
  */
 package com.hannonhill.umt.service;
 
+import java.io.BufferedWriter;
 import java.io.DataOutputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
@@ -447,11 +449,13 @@ public class RestApi
         authentication.addProperty("password", password);
         data.add("authentication", authentication);
 
+        
         DataOutputStream wr = new DataOutputStream(con.getOutputStream());
-        wr.writeBytes(data.toString());
-        wr.flush();
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(wr, "UTF-8"));
+        writer.write(data.toString());
+        writer.close();
         wr.close();
-
+        
         int responseCode = con.getResponseCode();
         if (responseCode != 200)
             throw new Exception(responseCode + " response code");

--- a/src/com/hannonhill/umt/service/RestApi.java
+++ b/src/com/hannonhill/umt/service/RestApi.java
@@ -109,7 +109,7 @@ public class RestApi
 
         // Append "/index" to path if there is already a folder with that path
         boolean movedDeeper = false;
-        if (projectInformation.getExistingCascadeFolders().get(path) != null)
+        if (projectInformation.getExistingCascadeFolders().get(path.toLowerCase()) != null)
         {
             path = path + "/index";
             movedDeeper = true;


### PR DESCRIPTION
Fixes issues with UTF-8 character encoding. Also, fixes issues with creation of an "index" page inside of a folder when original page is a sibling of the folder with the same name.