### PR TITLE
feat: Preserve order of Metadata and Data Definition fields

### DIFF
--- a/src/com/hannonhill/umt/service/RestApi.java
+++ b/src/com/hannonhill/umt/service/RestApi.java
@@ -12,11 +12,7 @@ import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.commons.lang.xwork.StringUtils;
 
@@ -309,7 +305,7 @@ public class RestApi
         MetadataSet metadataSet = readMetadataSet(projectInformation, contentType.getMetadataSetId());
 
         // add all the standard fields
-        Map<String, MetadataSetField> resultMap = new HashMap<>();
+        Map<String, MetadataSetField> resultMap = new LinkedHashMap<>();
         for (MetadataSetField field : STANDARD_METADATA_FIELDS)
             resultMap.put(field.getIdentifier(), field);
 

--- a/src/com/hannonhill/umt/service/XmlAnalyzer.java
+++ b/src/com/hannonhill/umt/service/XmlAnalyzer.java
@@ -5,14 +5,12 @@
  */
 package com.hannonhill.umt.service;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -35,10 +33,10 @@ public class XmlAnalyzer
 {
     /**
      * Analyzes a folder by going through each file in the folder and subfolders using
-     * {@link #analyzeFile(File, ProjectInformation)}.
+     * {@link XmlAnalyzer#analyzeFile(Path, ProjectInformation)}.
      * 
      * @param folder
-     * @param assetTypes
+     * @param projectInformation
      */
     public static void analyzeFolder(Path folder, ProjectInformation projectInformation)
     {
@@ -73,7 +71,7 @@ public class XmlAnalyzer
      */
     public static Map<String, DataDefinitionField> analyzeDataDefinitionXml(String xml) throws Exception
     {
-        Map<String, DataDefinitionField> returnMap = new HashMap<>();
+        Map<String, DataDefinitionField> returnMap = new LinkedHashMap<>();
         Node rootNode = XmlUtil.convertXmlToNodeStructure(new InputSource(new StringReader(xml)));
         NodeList children = rootNode.getChildNodes();
         analyzeDataDefinitionGroup(children, "", "", returnMap);


### PR DESCRIPTION
## Summary

When mapping fields, the order of metadata and data defintion fields within the select was not consistent with the order received from Cascade CMS. Switching to `LinkedHashMap` preserves that insertion order.